### PR TITLE
updated ng test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test",
+    "test": "ng test --browsers=ChromeHeadless --watch=false",
     "lint": "ng lint && npx stylelint \"**/*.scss\"",
     "prepare": "husky install"
   },


### PR DESCRIPTION
Restricted the test command to just run the test cases and proceed to the next test. If you want to watch the karma, you will need to make changes in the package.json file. You need to changes the test command to `ng test` after which you will be able to watch the test cases automate in the web browser.